### PR TITLE
ci: use node version 20 instead of 14

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install conventional-changelog-cli
         run: npm install -g conventional-changelog-cli


### PR DESCRIPTION
CI doesn't pass, the error message issued refer to a deprecated version of nodejs.